### PR TITLE
Fully `Sendable` support.

### DIFF
--- a/Sources/HTTPTypes/HTTPRequest.swift
+++ b/Sources/HTTPTypes/HTTPRequest.swift
@@ -22,7 +22,7 @@
 /// the "Host" header.
 public struct HTTPRequest: Sendable, Hashable {
     /// The HTTP request method
-    public struct Method: Hashable, RawRepresentable, LosslessStringConvertible {
+    public struct Method: Sendable, Hashable, RawRepresentable, LosslessStringConvertible {
         /// The string value of the request.
         public let rawValue: String
 

--- a/Sources/HTTPTypes/HTTPResponse.swift
+++ b/Sources/HTTPTypes/HTTPResponse.swift
@@ -18,7 +18,7 @@
 public struct HTTPResponse: Sendable, Hashable {
     /// The response status consisting of a 3-digit status code and a reason phrase. The reason
     /// phrase is ignored by modern HTTP versions.
-    public struct Status: Hashable, ExpressibleByIntegerLiteral, CustomStringConvertible {
+    public struct Status: Sendable, Hashable, ExpressibleByIntegerLiteral, CustomStringConvertible {
         /// The 3-digit status code.
         public let code: Int
         /// The reason phrase.

--- a/Tests/HTTPTypesTests/HTTPTypesTests.swift
+++ b/Tests/HTTPTypesTests/HTTPTypesTests.swift
@@ -72,4 +72,31 @@ final class HTTPTypesTests: XCTestCase {
         XCTAssertEqual(response2.headerFields.count, 3)
         XCTAssertEqual(response2.headerFields[.server], "HTTPServer/1.0")
     }
+
+    func testSendable() {
+        func isSendable(_ value: some Sendable) -> Bool { true }
+        func isSendable(_ value: Any) -> Bool { false }
+
+        let field: HTTPField = HTTPField(name: .userAgent, value: "")
+        let indexingStrategy: HTTPField.DynamicTableIndexingStrategy = field.indexingStrategy
+        let name: HTTPField.Name = field.name
+        let fields: HTTPFields = [:]
+        let request: HTTPRequest = HTTPRequest(method: .post, scheme: nil, authority: nil, path: nil)
+        let method: HTTPRequest.Method = request.method
+        let requestPseudoHeaderFields: HTTPRequest.PseudoHeaderFields = request.pseudoHeaderFields
+        let response: HTTPResponse = HTTPResponse(status: .ok)
+        let status: HTTPResponse.Status = response.status
+        let responsePseudoHeaderFields: HTTPResponse.PseudoHeaderFields = response.pseudoHeaderFields
+
+        XCTAssertTrue(isSendable(field))
+        XCTAssertTrue(isSendable(indexingStrategy))
+        XCTAssertTrue(isSendable(name))
+        XCTAssertTrue(isSendable(fields))
+        XCTAssertTrue(isSendable(request))
+        XCTAssertTrue(isSendable(method))
+        XCTAssertTrue(isSendable(requestPseudoHeaderFields))
+        XCTAssertTrue(isSendable(response))
+        XCTAssertTrue(isSendable(status))
+        XCTAssertTrue(isSendable(responsePseudoHeaderFields))
+    }
 }


### PR DESCRIPTION
This is a pull request that proposes making `Request.Method` and `Response.Status` conform to `Sendable`.

Currently, `Request.Method` and `Response.Status` don't conform to `Sendable`. In normal use, these types can be used without issues. However, instances of these types cannot be passed to other tasks in concurrency, or to be encapsulated into other types that conform to `Sendable`.