### PR TITLE
Fix equality check logic in HTTPResponse's `==` func

### DIFF
--- a/Sources/HTTPTypes/HTTPResponse.swift
+++ b/Sources/HTTPTypes/HTTPResponse.swift
@@ -195,7 +195,7 @@ public struct HTTPResponse: Sendable, Hashable {
     }
 
     public static func == (lhs: HTTPResponse, rhs: HTTPResponse) -> Bool {
-        lhs.pseudoHeaderFields == rhs.pseudoHeaderFields && lhs.headerFields == lhs.headerFields
+        lhs.pseudoHeaderFields == rhs.pseudoHeaderFields && lhs.headerFields == rhs.headerFields
     }
 }
 


### PR DESCRIPTION
Hi there, I noticed that in the `==` function for HTTPResponse, `lhs.headerFields` was being compared with itself instead of `rhs.headerFields`.
Hope this works!