### PR TITLE
Fix package not building for WASI

### DIFF
--- a/Sources/HTTPTypes/HTTPFields.swift
+++ b/Sources/HTTPTypes/HTTPFields.swift
@@ -14,8 +14,10 @@
 
 #if canImport(os.lock)
 import os.lock
-#else
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(WASILibc)
+import WASILibc
 #endif
 
 /// A collection of HTTP fields. It is used in `HTTPRequest` and `HTTPResponse`, and can also be

--- a/Sources/HTTPTypesFoundation/URLRequest+HTTPTypes.swift
+++ b/Sources/HTTPTypesFoundation/URLRequest+HTTPTypes.swift
@@ -18,6 +18,8 @@ import HTTPTypes
 import FoundationNetworking
 #endif
 
+#if !os(WASI)
+
 extension URLRequest {
     /// Create a `URLRequest` from an `HTTPRequest`.
     /// - Parameter httpRequest: The HTTP request to convert from.
@@ -63,3 +65,5 @@ extension URLRequest {
         return request
     }
 }
+
+#endif

--- a/Sources/HTTPTypesFoundation/URLResponse+HTTPTypes.swift
+++ b/Sources/HTTPTypesFoundation/URLResponse+HTTPTypes.swift
@@ -18,6 +18,8 @@ import HTTPTypes
 import FoundationNetworking
 #endif
 
+#if !os(WASI)
+
 extension HTTPURLResponse {
     /// Create an `HTTPURLResponse` from an `HTTPResponse`.
     /// - Parameter httpResponse: The HTTP response to convert from.
@@ -55,3 +57,5 @@ extension HTTPURLResponse {
         return response
     }
 }
+
+#endif

--- a/Sources/HTTPTypesFoundation/URLSession+HTTPTypes.swift
+++ b/Sources/HTTPTypesFoundation/URLSession+HTTPTypes.swift
@@ -18,6 +18,8 @@ import HTTPTypes
 import FoundationNetworking
 #endif
 
+#if !os(WASI)
+
 extension URLSessionTask {
     /// The original HTTP request this task was created with.
     public var originalHTTPRequest: HTTPRequest? {
@@ -39,6 +41,8 @@ private enum HTTPTypeConversionError: Error {
     case failedToConvertHTTPRequestToURLRequest
     case failedToConvertURLResponseToHTTPResponse
 }
+
+#endif
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
 


### PR DESCRIPTION
This package currently doesn't build for WASI, as it refers to platform-specific types like `URLSession`, `URLRequest`, and `URLResponse` types not guarded by OS checks. With these new checks the package builds for `wasm32-unknown-wasi` triple successfully.