### PR TITLE
Optimise initialization of HTTPFields through Dictionary Literal

### DIFF
--- a/Benchmarks/.gitignore
+++ b/Benchmarks/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Benchmarks/Benchmarks/HTTPFieldsBenchmarks/Benchmarks.swift
+++ b/Benchmarks/Benchmarks/HTTPFieldsBenchmarks/Benchmarks.swift
@@ -1,0 +1,16 @@
+import HTTPTypes
+import Benchmark
+
+let benchmarks = {
+    Benchmark(
+        "Initialize HTTPFields from Dictionary Literal"
+    ) { benchmark in
+        let fiels: HTTPFields = [
+            .contentType: "application/json",
+            .contentLength: "42",
+            .connection: "keep-alive",
+            .accept: "application/json",
+            .acceptEncoding: "gzip, deflate, br",
+        ]
+    }
+}

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version: 5.7.1
+
+import PackageDescription
+
+let package = Package(
+    name: "Benchmarks",
+    platforms: [
+        .macOS(.v13)
+    ],
+    dependencies: [
+        .package(path: "../"),
+        .package(url: "https://github.com/ordo-one/package-benchmark.git", from: "1.22.1"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "Benchmarks",
+            dependencies: [
+                .product(name: "Benchmark", package: "package-benchmark"),
+                .product(name: "HTTPTypes", package: "swift-http-types"),
+            ],
+            path: "Benchmarks/HTTPFieldsBenchmarks",
+            plugins: [
+                .plugin(name: "BenchmarkPlugin", package: "package-benchmark")
+            ]
+        ),
+    ]
+)

--- a/Sources/HTTPTypes/HTTPFields.swift
+++ b/Sources/HTTPTypes/HTTPFields.swift
@@ -280,6 +280,7 @@ public struct HTTPFields: Sendable, Hashable {
 
 extension HTTPFields: ExpressibleByDictionaryLiteral {
     public init(dictionaryLiteral elements: (HTTPField.Name, String)...) {
+        self.reserveCapacity(elements.count)
         for (name, value) in elements {
             precondition(!name.isPseudo, "Pseudo header field \"\(name)\" disallowed")
             self._storage.append(field: HTTPField(name: name, value: value))


### PR DESCRIPTION
# Before

```
╒═══════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│ Metric                        │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞═══════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│ Malloc (total) *              │      19 │      19 │      19 │      19 │      19 │      19 │      19 │   10000 │
├───────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Memory (resident peak) (K)    │    8700 │    9069 │    9069 │    9085 │    9110 │    9110 │    9110 │   10000 │
├───────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Throughput (# / s) (K)        │     149 │     146 │     145 │     141 │     140 │     106 │       6 │   10000 │
├───────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Time (total CPU) (μs) *       │      39 │      40 │      40 │      41 │      41 │      49 │     104 │   10000 │
├───────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Time (wall clock) (ns) *      │    6708 │    6835 │    6919 │    7083 │    7167 │    9295 │  176083 │   10000 │
╘═══════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛
```

# After

```
╒═══════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│ Metric                        │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞═══════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│ Malloc (total) *              │      14 │      14 │      14 │      14 │      14 │      14 │      14 │   10000 │
├───────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Memory (resident peak) (K)    │    8700 │    9052 │    9052 │    9069 │    9093 │    9093 │    9093 │   10000 │
├───────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Throughput (# / s) (K)        │     242 │     235 │     233 │     227 │     224 │     151 │      20 │   10000 │
├───────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Time (total CPU) (μs) *       │      34 │      35 │      35 │      36 │      36 │      44 │      97 │   10000 │
├───────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Time (wall clock) (ns) *      │    4125 │    4251 │    4295 │    4419 │    4459 │    6583 │   51166 │   10000 │
╘═══════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛
```