### PR TITLE
Update HTTPResponse.swift - added HTTP Response 418

### DIFF
--- a/Sources/HTTPTypes/HTTPResponse.swift
+++ b/Sources/HTTPTypes/HTTPResponse.swift
@@ -460,6 +460,11 @@ extension HTTPResponse.Status {
     /// https://www.rfc-editor.org/rfc/rfc9110.html
     public static var expectationFailed: Self { .init(uncheckedCode: 417, reasonPhrase: "Expectation Failed") }
 
+    /// 418 I'm a teapot
+    ///
+    /// https://www.rfc-editor.org/rfc/rfc9110.html#section-15.5.19
+    public static var imATeapot: Self { .init(uncheckedCode: 418, reasonPhrase: "I'm a teapot") }
+    
     /// 421 Misdirected Request
     ///
     /// https://www.rfc-editor.org/rfc/rfc9110.html


### PR DESCRIPTION
As April 1st is right around the corner, I recognised that this repo lacked support for responses detailed in [RFC 2324](https://www.rfc-editor.org/rfc/rfc2324) ☕️