### PR TITLE
Support lenient legalization of header field values

### DIFF
--- a/Sources/HTTPTypes/HTTPField.swift
+++ b/Sources/HTTPTypes/HTTPField.swift
@@ -71,7 +71,8 @@ public struct HTTPField: Sendable, Hashable {
     /// Create an HTTP field from a name and a value. Leniently legalize the value.
     /// - Parameters:
     ///   - name: The HTTP field name.
-    ///   - value: The HTTP field value. Newlines and NULs are converted into space characters.
+    ///   - lenientValue: The HTTP field value. Newlines and NULs are converted into space
+    ///                   characters.
     public init(name: Name, lenientValue: some Collection<UInt8>) {
         self.name = name
         self.rawValue = Self.lenientLegalizeValue(ISOLatin1String(lenientValue))

--- a/Tests/HTTPTypesTests/HTTPTypesTests.swift
+++ b/Tests/HTTPTypesTests/HTTPTypesTests.swift
@@ -38,6 +38,7 @@ final class HTTPTypesTests: XCTestCase {
         XCTAssertEqual(HTTPField(name: .accept, value: " a 😀 \t\n b \t \r ").value, "a 😀 \t  b")
         XCTAssertEqual(HTTPField(name: .accept, value: "").value, "")
         XCTAssertFalse(HTTPField.isValidValue(" "))
+        XCTAssertEqual(HTTPField(name: .accept, lenientValue: "  \r\n\0\t ".utf8).value, "     \t ")
     }
 
     func testRequest() {


### PR DESCRIPTION
This is needed to pass Web Platform Tests where they expect invalid characters in header field values to be preserved