### PR TITLE
Support compiling against Musl

### DIFF
--- a/Sources/HTTPTypes/HTTPFields.swift
+++ b/Sources/HTTPTypes/HTTPFields.swift
@@ -16,6 +16,8 @@
 import os.lock
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif canImport(WASILibc)
 import WASILibc
 #endif


### PR DESCRIPTION
### Motivation

When building for Linux, we would like to be able to build this package on top of Musl, as well as the usual Glibc.

### Modifications

Conditionally import `Musl` when present, just like we do for `Glibc`.

### Result

Can compile against Musl.