### PR TITLE
Make status and method directly codable

### DIFF
--- a/Sources/HTTPTypes/HTTPRequest.swift
+++ b/Sources/HTTPTypes/HTTPRequest.swift
@@ -318,6 +318,23 @@ extension HTTPRequest: Codable {
     }
 }
 
+extension HTTPRequest.Method: Codable {
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(self.rawValue)
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawMethod = try container.decode(String.self)
+        guard let method = HTTPRequest.Method(rawMethod) else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "\"\(rawMethod)\" is not a valid method")
+        }
+
+        self = method
+    }
+}
+
 extension HTTPRequest.Method {
     /// GET
     ///

--- a/Sources/HTTPTypes/HTTPResponse.swift
+++ b/Sources/HTTPTypes/HTTPResponse.swift
@@ -281,6 +281,18 @@ extension HTTPResponse: Codable {
     }
 }
 
+extension HTTPResponse.Status: Codable {
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(self.code)
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let code = try decoder.singleValueContainer().decode(Int.self)
+        self.init(code: code)
+    }
+}
+
 extension HTTPResponse.Status {
     // MARK: 1xx
 


### PR DESCRIPTION
Closes #51 

Over in the Swift AWS Lambda events, we are looking at using some of the Swift HTTP types, see this PR: https://github.com/swift-server/swift-aws-lambda-events/pull/47 

One thing I haven't handled in the `Codable` of `HTTPResponse.Status` is the `reasonPhrase`, as that wouldn't work decoding from a lot of places we find a status represented in AWS JSON as just a number. Which makes me thinks if this is even the right thing to do...

/cc @sebsto