### PR TITLE
Add HTTPClient for Web API Client Library

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,6 +19,18 @@ let package = Package(
                 "HTTPTypes",
             ]
         ),
+        .target(
+            name: "HTTPClient",
+            dependencies: [
+                .target(name: "HTTPTypes"),
+            ]
+        ),
+        .target(
+            name: "HTTPClientFoundation",
+            dependencies: [
+                .target(name: "HTTPClient"),
+            ]
+        ),
         .testTarget(
             name: "HTTPTypesTests",
             dependencies: [

--- a/Sources/HTTPClient/HTTPClient.swift
+++ b/Sources/HTTPClient/HTTPClient.swift
@@ -1,0 +1,7 @@
+import Foundation
+import HTTPTypes
+
+public protocol HTTPClientProtocol {
+  @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+  func execute(for request: HTTPRequest, from body: Data?) async throws -> (Data, HTTPResponse)
+}

--- a/Sources/HTTPClientFoundation/URLSession++HTTPClient.swift
+++ b/Sources/HTTPClientFoundation/URLSession++HTTPClient.swift
@@ -1,0 +1,30 @@
+import Foundation
+import HTTPClient
+import HTTPTypes
+import HTTPTypesFoundation
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS) || compiler(>=6)
+  @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+  extension URLSession: HTTPClientProtocol {
+    public func execute(
+      for request: HTTPRequest,
+      from bodyData: Data?
+    ) async throws -> (Data, HTTPResponse) {
+      if let bodyData {
+        try await self.upload(for: request, from: bodyData)
+      } else {
+        try await self.data(for: request)
+      }
+    }
+  }
+
+  extension HTTPClientProtocol where Self == URLSession {
+    public static func urlSession(_ urlSession: Self) -> Self {
+      return urlSession
+    }
+  }
+#endif


### PR DESCRIPTION
## HTTPClient

Web API Client Library needs `HTTPClient` for `URLSession`, `SwiftNIO`...

## Example: GitHub API Client Library

```swift
import Foundation
import HTTPTypes
import HTTPClient
import HTTPClientFoundatiaon

let api = GitHubAPI(
  token: <#API_TOKEN#>,
  httpClient: .urlSession(.shared)
)

let user = try await api.user(id: <#USER_ID#>)

struct GitHubAPI<HTTPClient: HTTPClientProtocol>: Sendable where HTTPClient: Sendable {
  let token: String
  let httpClient: HTTPClient

  func user(id: String) async throws -> User {
    let request = HTTPRequest(
      method: .get,
      url: url,
      headerFields: [.authorization: token]
    )
    let (data, response) = try await httpClient.execute(for: request, from: nil)
    let user = try JSONDecoder().decode(User.self, from: data)
    return user
  }
}
```
