### PR TITLE
Adopt Mutex where available

### DIFF
--- a/Benchmarks/Thresholds/6.0/Benchmarks.HTTPFields.init(dictionaryLiteral).p90.json
+++ b/Benchmarks/Thresholds/6.0/Benchmarks.HTTPFields.init(dictionaryLiteral).p90.json
@@ -1,3 +1,3 @@
 {
-  "mallocCountTotal" : 14
+  "mallocCountTotal" : 13
 }

--- a/Benchmarks/Thresholds/nightly-6.0/Benchmarks.HTTPFields.init(dictionaryLiteral).p90.json
+++ b/Benchmarks/Thresholds/nightly-6.0/Benchmarks.HTTPFields.init(dictionaryLiteral).p90.json
@@ -1,3 +1,3 @@
 {
-  "mallocCountTotal" : 14
+  "mallocCountTotal" : 13
 }

--- a/Benchmarks/Thresholds/nightly-main/Benchmarks.HTTPFields.init(dictionaryLiteral).p90.json
+++ b/Benchmarks/Thresholds/nightly-main/Benchmarks.HTTPFields.init(dictionaryLiteral).p90.json
@@ -1,3 +1,3 @@
 {
-  "mallocCountTotal" : 14
+  "mallocCountTotal" : 13
 }

--- a/Sources/HTTPTypes/HTTPFields.swift
+++ b/Sources/HTTPTypes/HTTPFields.swift
@@ -12,9 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(Synchronization)
+#if compiler(>=6.0)
 import Synchronization
-#endif  // canImport(Synchronization)
+#endif  // compiler(>=6.0)
 
 /// A collection of HTTP fields. It is used in `HTTPRequest` and `HTTPResponse`, and can also be
 /// used as HTTP trailer fields.
@@ -109,7 +109,7 @@ public struct HTTPFields: Sendable, Hashable {
         }
     }
 
-    #if canImport(Synchronization)
+    #if compiler(>=6.0)
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     private final class _StorageWithMutex: _Storage, @unchecked Sendable {
         let mutex = Mutex<Void>(())
@@ -120,7 +120,7 @@ public struct HTTPFields: Sendable, Hashable {
             }
         }
     }
-    #endif  // canImport(Synchronization)
+    #endif  // compiler(>=6.0)
 
     private final class _StorageWithNIOLock: _Storage, @unchecked Sendable {
         let lock = LockStorage.create(value: ())
@@ -133,15 +133,15 @@ public struct HTTPFields: Sendable, Hashable {
     }
 
     private var _storage = {
-        #if canImport(Synchronization)
+        #if compiler(>=6.0)
         if #available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *) {
             _StorageWithMutex()
         } else {
             _StorageWithNIOLock()
         }
-        #else  // canImport(Synchronization)
+        #else  // compiler(>=6.0)
         _StorageWithNIOLock()
-        #endif  // canImport(Synchronization)
+        #endif  // compiler(>=6.0)
     }()
 
     /// Create an empty list of HTTP fields


### PR DESCRIPTION
Mutex should eliminate the extra allocation. Subclassing is the only way I found to work. I tried enums (enum case cannot be unavailable) and class-bound protocols (`isKnownUniquelyReferenced` doesn't work). @FranzBusch