### PR TITLE
Request.url should return nil for situations where it is not applicable

### DIFF
--- a/Sources/HTTPTypesFoundation/HTTPRequest+URL.swift
+++ b/Sources/HTTPTypesFoundation/HTTPRequest+URL.swift
@@ -24,6 +24,11 @@ extension HTTPRequest {
     /// fields.
     public var url: URL? {
         get {
+            if (self.method == .connect && self.extendedConnectProtocol == nil)
+                || (self.method == .options && self.path == "*")
+            {
+                return nil
+            }
             if let schemeField = self.pseudoHeaderFields.scheme,
                 let authorityField = self.pseudoHeaderFields.authority,
                 let pathField = self.pseudoHeaderFields.path

--- a/Tests/HTTPTypesFoundationTests/HTTPTypesFoundationTests.swift
+++ b/Tests/HTTPTypesFoundationTests/HTTPTypesFoundationTests.swift
@@ -91,8 +91,21 @@ final class HTTPTypesFoundationTests: XCTestCase {
             path: "www.example.com:443"
         )
         XCTAssertNil(request1.url)
-        let request2 = HTTPRequest(method: .options, scheme: "https", authority: "www.example.com", path: "*")
-        XCTAssertNil(request2.url)
+
+        var request2 = HTTPRequest(
+            method: .connect,
+            scheme: "https",
+            authority: "www.example.com",
+            path: "/"
+        )
+        request2.extendedConnectProtocol = "websocket"
+        XCTAssertEqual(request2.url?.absoluteString, "https://www.example.com/")
+
+        let request3 = HTTPRequest(method: .options, scheme: "https", authority: "www.example.com", path: "*")
+        XCTAssertNil(request3.url)
+
+        let request4 = HTTPRequest(method: .options, scheme: "https", authority: "www.example.com", path: "/")
+        XCTAssertEqual(request4.url?.absoluteString, "https://www.example.com/")
     }
 
     func testRequestToFoundation() throws {

--- a/Tests/HTTPTypesFoundationTests/HTTPTypesFoundationTests.swift
+++ b/Tests/HTTPTypesFoundationTests/HTTPTypesFoundationTests.swift
@@ -83,6 +83,18 @@ final class HTTPTypesFoundationTests: XCTestCase {
         XCTAssertEqual(request4.url?.absoluteString, "https://127.0.0.1:443/")
     }
 
+    func testNilRequestURL() {
+        let request1 = HTTPRequest(
+            method: .connect,
+            scheme: "https",
+            authority: "www.example.com:443",
+            path: "www.example.com:443"
+        )
+        XCTAssertNil(request1.url)
+        let request2 = HTTPRequest(method: .options, scheme: "https", authority: "www.example.com", path: "*")
+        XCTAssertNil(request2.url)
+    }
+
     func testRequestToFoundation() throws {
         let request = HTTPRequest(
             method: .get,


### PR DESCRIPTION
Regular CONNECT requests and OPTIONS * requests do not have URLs