### PR TITLE
Eliminate hasPrefix usage for pseudo HTTP header names

### DIFF
--- a/Sources/HTTPTypes/HTTPFieldName.swift
+++ b/Sources/HTTPTypes/HTTPFieldName.swift
@@ -61,7 +61,7 @@ extension HTTPField {
                 return nil
             }
             let token: Substring
-            if name.hasPrefix(":") {
+            if name.utf8.first == UInt8(ascii: ":") {
                 token = name.dropFirst()
             } else {
                 token = Substring(name)
@@ -90,7 +90,7 @@ extension HTTPField {
         }
 
         var isPseudo: Bool {
-            self.rawName.hasPrefix(":")
+            self.rawName.utf8.first == UInt8(ascii: ":")
         }
     }
 }
@@ -126,7 +126,7 @@ extension HTTPField.Name: Codable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         let nameString = try container.decode(String.self)
-        if nameString.hasPrefix(":") {
+        if nameString.utf8.first == UInt8(ascii: ":") {
             guard nameString.lowercased() == nameString,
                 HTTPField.isValidToken(nameString.dropFirst())
             else {

--- a/Sources/HTTPTypes/HTTPRequest.swift
+++ b/Sources/HTTPTypes/HTTPRequest.swift
@@ -298,7 +298,7 @@ extension HTTPRequest.PseudoHeaderFields: Codable {
                 }
                 extendedConnectProtocol = field
             default:
-                guard field.name.rawName.hasPrefix(":") else {
+                guard field.name.rawName.utf8.first == UInt8(ascii: ":") else {
                     throw DecodingError.dataCorruptedError(
                         in: container,
                         debugDescription: "\"\(field)\" is not a pseudo header field"

--- a/Sources/HTTPTypes/HTTPResponse.swift
+++ b/Sources/HTTPTypes/HTTPResponse.swift
@@ -239,7 +239,7 @@ extension HTTPResponse.PseudoHeaderFields: Codable {
                 }
                 status = field
             default:
-                guard field.name.rawName.hasPrefix(":") else {
+                guard field.name.rawName.utf8.first == UInt8(ascii: ":") else {
                     throw DecodingError.dataCorruptedError(
                         in: container,
                         debugDescription: "\"\(field)\" is not a pseudo header field"


### PR DESCRIPTION
UTF8 view is faster than hasPrefix

rdar://144395951