### PR TITLE
Convert WebSocket URLRequest to RFC8441 HTTPRequest

### DIFF
--- a/Tests/HTTPTypesFoundationTests/HTTPTypesFoundationTests.swift
+++ b/Tests/HTTPTypesFoundationTests/HTTPTypesFoundationTests.swift
@@ -143,6 +143,22 @@ final class HTTPTypesFoundationTests: XCTestCase {
         XCTAssertEqual(request.headerFields[.init("x-foo")!], "Bar")
     }
 
+    func testWebSocketRequest() throws {
+        let urlRequest = URLRequest(url: URL(string: "wss://www.example.com/")!)
+
+        let request = try XCTUnwrap(urlRequest.httpRequest)
+        XCTAssertEqual(request.method, .connect)
+        XCTAssertEqual(request.scheme, "https")
+        XCTAssertEqual(request.authority, "www.example.com")
+        XCTAssertEqual(request.path, "/")
+        XCTAssertEqual(request.extendedConnectProtocol, "websocket")
+
+        let urlRequestConverted = try XCTUnwrap(URLRequest(httpRequest: request))
+        XCTAssertEqual(urlRequestConverted.httpMethod, "GET")
+        XCTAssertEqual(urlRequestConverted.url, URL(string: "wss://www.example.com/"))
+        XCTAssertEqual(urlRequest, urlRequestConverted)
+    }
+
     func testResponseToFoundation() throws {
         let response = HTTPResponse(
             status: .ok,


### PR DESCRIPTION
WebSocket uses the extended-CONNECT form in HTTP/2 and HTTP/3. When creating an HTTPRequest from a URLRequest, we should translate it into the new form.

`:method`: `GET` -> `CONNECT`
`:scheme`: `wss`/`ws` -> `https`/`http`
`:protocol`: `websocket`

HTTPTypes defaults to modern HTTP versions, and the expectation is that the HTTP/1 serializer has to translate the extended-CONNECT request back to the old request form.