### PR TITLE
Remove soundness.sh script instructions from CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,32 +54,6 @@ A good patch is:
 3. Documented, adding API documentation as needed to cover new functions and properties.
 4. Accompanied by a great commit message, using our commit message template.
 
-### Run `./scripts/soundness.sh`
-
-The scripts directory contains a [soundness.sh script](https://github.com/apple/swift-http-types/blob/main/scripts/soundness.sh) 
-that enforces additional checks, like license headers and formatting style.
-
-Please make sure to `./scripts/soundness.sh` before pushing a change upstream, otherwise it is likely the PR validation will fail
-on minor changes such as a missing `self.` or similar formatting issues.
-
-> The script also executes the above mentioned `generate_linux_tests.rb`.
-
-For frequent contributors, we recommend adding the script as a [git pre-push hook](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks), which you can do via executing the following command in the project root directory: 
-
-```sh
-cat << EOF > .git/hooks/pre-push
-#!/bin/sh
-
-if [ -f "scripts/soundness.sh" ]; then
-  scripts/soundness.sh
-fi
-EOF
-```
-
-Which makes the script execute, and only allow the `git push` to complete if the check has passed.
-
-In the case of formatting issues, you can then `git add` the formatting changes, and attempt the push again. 
-
 ## How to contribute your work
 
 Please open a pull request at https://github.com/apple/swift-http-types. Make sure the CI passes, and then wait for code review.


### PR DESCRIPTION
Removed instructions for running the soundness.sh script and adding it as a git pre-push hook as the script does not exist anymore.