### PR TITLE
Remove 6.0 compiler checks

### DIFF
--- a/Sources/HTTPTypes/HTTPFields.swift
+++ b/Sources/HTTPTypes/HTTPFields.swift
@@ -12,9 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6.0)
 import Synchronization
-#endif  // compiler(>=6.0)
 
 /// A collection of HTTP fields. It is used in `HTTPRequest` and `HTTPResponse`, and can also be
 /// used as HTTP trailer fields.
@@ -109,7 +107,6 @@ public struct HTTPFields: Sendable, Hashable {
         }
     }
 
-    #if compiler(>=6.0)
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     private final class _StorageWithMutex: _Storage, @unchecked Sendable {
         let mutex = Mutex<Void>(())
@@ -120,8 +117,8 @@ public struct HTTPFields: Sendable, Hashable {
             }
         }
     }
-    #endif  // compiler(>=6.0)
 
+    #if canImport(Darwin)
     private final class _StorageWithNIOLock: _Storage, @unchecked Sendable {
         let lock = LockStorage.create(value: ())
 
@@ -131,17 +128,18 @@ public struct HTTPFields: Sendable, Hashable {
             }
         }
     }
+    #endif
 
     private var _storage = {
-        #if compiler(>=6.0)
+        #if canImport(Darwin)
         if #available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *) {
             _StorageWithMutex()
         } else {
             _StorageWithNIOLock()
         }
-        #else  // compiler(>=6.0)
-        _StorageWithNIOLock()
-        #endif  // compiler(>=6.0)
+        #else
+        _StorageWithMutex()
+        #endif
     }()
 
     /// Create an empty list of HTTP fields

--- a/Sources/HTTPTypesFoundation/URLSession+HTTPTypes.swift
+++ b/Sources/HTTPTypesFoundation/URLSession+HTTPTypes.swift
@@ -45,8 +45,6 @@ private enum HTTPTypeConversionError: Error {
 
 #endif
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || compiler(>=6) || (compiler(>=6) && os(visionOS))
-
 @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
 extension URLSession {
     /// Convenience method to load data using an `HTTPRequest`; creates and resumes a `URLSessionDataTask` internally.
@@ -129,7 +127,7 @@ extension URLSession {
         return (location, response)
     }
 
-    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || (compiler(>=6) && os(visionOS))
+    #if canImport(Darwin)
     /// Returns a byte stream that conforms to AsyncSequence protocol.
     ///
     /// - Parameter request: The `HTTPRequest` for which to load data.
@@ -200,5 +198,3 @@ extension URLSession {
         return (data, response)
     }
 }
-
-#endif


### PR DESCRIPTION
`_StorageWithNIOLock` is no longer needed on non-Darwin platforms