### PR TITLE
Drop Swift 6.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,19 +16,16 @@ jobs:
     with:
       linux_5_9_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_5_10_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
-      linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_6_1_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_6_2_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_6_3_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
-      windows_6_0_enabled: true
       windows_6_1_enabled: true
       windows_6_2_enabled: true
       windows_6_3_enabled: true
       windows_nightly_next_enabled: true
       windows_nightly_main_enabled: true
-      windows_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       windows_6_1_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       windows_6_2_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       windows_6_3_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
@@ -61,7 +58,6 @@ jobs:
     name: Release builds
     uses: apple/swift-nio/.github/workflows/release_builds.yml@main
     with:
-      windows_6_0_enabled: true
       windows_6_1_enabled: true
       windows_6_2_enabled: true
       windows_6_3_enabled: true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,19 +20,16 @@ jobs:
     with:
       linux_5_9_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_5_10_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
-      linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_6_1_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_6_2_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_6_3_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
-      windows_6_0_enabled: true
       windows_6_1_enabled: true
       windows_6_2_enabled: true
       windows_6_3_enabled: true
       windows_nightly_next_enabled: true
       windows_nightly_main_enabled: true
-      windows_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       windows_6_1_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       windows_6_2_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       windows_6_3_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
@@ -65,7 +62,6 @@ jobs:
     name: Release builds
     uses: apple/swift-nio/.github/workflows/release_builds.yml@main
     with:
-      windows_6_0_enabled: true
       windows_6_1_enabled: true
       windows_6_2_enabled: true
       windows_6_3_enabled: true

--- a/Benchmarks/Benchmarks/HTTPFieldsBenchmarks/Benchmarks.swift
+++ b/Benchmarks/Benchmarks/HTTPFieldsBenchmarks/Benchmarks.swift
@@ -15,7 +15,7 @@
 import Benchmark
 import HTTPTypes
 
-let benchmarks = {
+let benchmarks: @Sendable () -> Void = {
     let defaultMetrics: [BenchmarkMetric] = [
         .mallocCountTotal
     ]

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7.1
+// swift-tools-version:6.1
 
 import PackageDescription
 

--- a/Benchmarks/Thresholds/5.10/Benchmarks.HTTPFields.init(dictionaryLiteral).p90.json
+++ b/Benchmarks/Thresholds/5.10/Benchmarks.HTTPFields.init(dictionaryLiteral).p90.json
@@ -1,3 +1,0 @@
-{
-  "mallocCountTotal" : 14
-}

--- a/Benchmarks/Thresholds/5.9/Benchmarks.HTTPFields.init(dictionaryLiteral).p90.json
+++ b/Benchmarks/Thresholds/5.9/Benchmarks.HTTPFields.init(dictionaryLiteral).p90.json
@@ -1,3 +1,0 @@
-{
-  "mallocCountTotal" : 14
-}

--- a/Benchmarks/Thresholds/6.0/Benchmarks.HTTPFields.init(dictionaryLiteral).p90.json
+++ b/Benchmarks/Thresholds/6.0/Benchmarks.HTTPFields.init(dictionaryLiteral).p90.json
@@ -1,3 +1,0 @@
-{
-  "mallocCountTotal" : 13
-}

--- a/Benchmarks/Thresholds/nightly-6.1
+++ b/Benchmarks/Thresholds/nightly-6.1
@@ -1,1 +1,0 @@
-./nightly-next

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version:6.1
 
 import PackageDescription
 

--- a/Sources/HTTPTypes/HTTPFields.swift
+++ b/Sources/HTTPTypes/HTTPFields.swift
@@ -12,9 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6.0)
 import Synchronization
-#endif  // compiler(>=6.0)
 
 /// A collection of HTTP fields. It is used in `HTTPRequest` and `HTTPResponse`, and can also be
 /// used as HTTP trailer fields.
@@ -109,7 +107,6 @@ public struct HTTPFields: Sendable, Hashable {
         }
     }
 
-    #if compiler(>=6.0)
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     private final class _StorageWithMutex: _Storage, @unchecked Sendable {
         let mutex = Mutex<Void>(())
@@ -120,7 +117,6 @@ public struct HTTPFields: Sendable, Hashable {
             }
         }
     }
-    #endif  // compiler(>=6.0)
 
     private final class _StorageWithNIOLock: _Storage, @unchecked Sendable {
         let lock = LockStorage.create(value: ())
@@ -133,15 +129,11 @@ public struct HTTPFields: Sendable, Hashable {
     }
 
     private var _storage = {
-        #if compiler(>=6.0)
         if #available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *) {
             _StorageWithMutex()
         } else {
             _StorageWithNIOLock()
         }
-        #else  // compiler(>=6.0)
-        _StorageWithNIOLock()
-        #endif  // compiler(>=6.0)
     }()
 
     /// Create an empty list of HTTP fields

--- a/Sources/HTTPTypes/HTTPFields.swift
+++ b/Sources/HTTPTypes/HTTPFields.swift
@@ -118,6 +118,7 @@ public struct HTTPFields: Sendable, Hashable {
         }
     }
 
+    #if canImport(Darwin)
     private final class _StorageWithNIOLock: _Storage, @unchecked Sendable {
         let lock = LockStorage.create(value: ())
 
@@ -127,13 +128,18 @@ public struct HTTPFields: Sendable, Hashable {
             }
         }
     }
+    #endif
 
     private var _storage = {
+        #if canImport(Darwin)
         if #available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *) {
             _StorageWithMutex()
         } else {
             _StorageWithNIOLock()
         }
+        #else
+        _StorageWithMutex()
+        #endif
     }()
 
     /// Create an empty list of HTTP fields

--- a/Sources/HTTPTypesFoundation/URLSession+HTTPTypes.swift
+++ b/Sources/HTTPTypesFoundation/URLSession+HTTPTypes.swift
@@ -45,8 +45,6 @@ private enum HTTPTypeConversionError: Error {
 
 #endif
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || compiler(>=6) || (compiler(>=6) && os(visionOS))
-
 @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
 extension URLSession {
     /// Convenience method to load data using an `HTTPRequest`; creates and resumes a `URLSessionDataTask` internally.
@@ -129,7 +127,7 @@ extension URLSession {
         return (location, response)
     }
 
-    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || (compiler(>=6) && os(visionOS))
+    #if canImport(Darwin)
     /// Returns a byte stream that conforms to AsyncSequence protocol.
     ///
     /// - Parameter request: The `HTTPRequest` for which to load data.
@@ -200,5 +198,3 @@ extension URLSession {
         return (data, response)
     }
 }
-
-#endif


### PR DESCRIPTION
Motivation:

Swift 6.0 is no longer supported, we should bump the tools version and remove it from our CI.

Modifications:

* Bump the Swift tools version to Swift 6.1
* Remove Swift 6.0 jobs where appropriate in main.yml, pull_request.yml

Result:

Code reflects our support window.
