### PR TITLE
Support embedded Swift

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -58,6 +58,12 @@ jobs:
       runner_pool: general
       build_scheme: swift-http-types-Package
 
+  wasm-sdk:
+    name: WebAssembly Swift SDK
+    uses: apple/swift-nio/.github/workflows/wasm_swift_sdk.yml@main
+    with:
+      additional_command_arguments: "--target HTTPTypes"
+
   release-builds:
     name: Release builds
     uses: apple/swift-nio/.github/workflows/release_builds.yml@main

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -60,7 +60,7 @@ jobs:
 
   embedded-swift:
     name: Build with Embedded Swift
-    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.10
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.9
     with:
       enable_linux_checks: true
       enable_macos_checks: true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -58,11 +58,16 @@ jobs:
       runner_pool: general
       build_scheme: swift-http-types-Package
 
-  wasm-sdk:
-    name: WebAssembly Swift SDK
-    uses: apple/swift-nio/.github/workflows/wasm_swift_sdk.yml@main
+  embedded-swift:
+    name: Build with Embedded Swift
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.10
     with:
-      additional_command_arguments: "--target HTTPTypes"
+      enable_linux_checks: true
+      enable_macos_checks: true
+      enable_windows_checks: true
+      enable_wasm_sdk_build: true
+      enable_embedded_wasm_sdk_build: true
+      swift_flags: --target HTTPTypes
 
   release-builds:
     name: Release builds

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -62,9 +62,9 @@ jobs:
     name: Build with Embedded Swift
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.9
     with:
-      enable_linux_checks: true
-      enable_macos_checks: true
-      enable_windows_checks: true
+      enable_linux_checks: false
+      enable_macos_checks: false
+      enable_windows_checks: false
       enable_wasm_sdk_build: true
       enable_embedded_wasm_sdk_build: true
       swift_flags: --target HTTPTypes

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -60,7 +60,7 @@ jobs:
 
   embedded-swift:
     name: Build with Embedded Swift
-    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.9
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.11
     with:
       enable_linux_checks: false
       enable_macos_checks: false

--- a/Sources/HTTPTypes/HTTPField.swift
+++ b/Sources/HTTPTypes/HTTPField.swift
@@ -219,6 +219,8 @@ extension HTTPField: CustomStringConvertible {
     }
 }
 
+#if !hasFeature(Embedded)
+
 extension HTTPField: CustomPlaygroundDisplayConvertible {
     public var playgroundDescription: Any {
         self.description
@@ -260,6 +262,8 @@ extension HTTPField: Codable {
         }
     }
 }
+
+#endif
 
 extension HTTPField {
     static func isValidToken(_ token: some StringProtocol) -> Bool {

--- a/Sources/HTTPTypes/HTTPField.swift
+++ b/Sources/HTTPTypes/HTTPField.swift
@@ -112,9 +112,9 @@ public struct HTTPField: Sendable, Hashable {
     ///
     /// - Parameter body: The closure to be invoked with the buffer.
     /// - Returns: Result of the `body` closure.
-    public func withUnsafeBytesOfValue<Result>(
-        _ body: (UnsafeBufferPointer<UInt8>) throws -> Result
-    ) rethrows -> Result {
+    public func withUnsafeBytesOfValue<Result, Failure: Error>(
+        _ body: (UnsafeBufferPointer<UInt8>) throws(Failure) -> Result
+    ) throws(Failure) -> Result {
         try self.rawValue.withUnsafeBytes(body)
     }
 

--- a/Sources/HTTPTypes/HTTPFieldName.swift
+++ b/Sources/HTTPTypes/HTTPFieldName.swift
@@ -111,6 +111,8 @@ extension HTTPField.Name: LosslessStringConvertible {
     }
 }
 
+#if !hasFeature(Embedded)
+
 extension HTTPField.Name: CustomPlaygroundDisplayConvertible {
     public var playgroundDescription: Any {
         self.description
@@ -147,6 +149,8 @@ extension HTTPField.Name: Codable {
         }
     }
 }
+
+#endif
 
 extension HTTPField.Name {
     static var method: Self { .init(rawName: ":method", canonicalName: ":method") }

--- a/Sources/HTTPTypes/HTTPFields.swift
+++ b/Sources/HTTPTypes/HTTPFields.swift
@@ -30,13 +30,24 @@ public struct HTTPFields: Sendable, Hashable {
         required init() {
         }
 
-        #if !hasFeature(Embedded)
+        #if canImport(Darwin) && !hasFeature(Embedded)
         func withLock<Result, Failure: Error>(_ body: () throws(Failure) -> Result) throws(Failure) -> Result {
             fatalError()
         }
         #else
+        #if !hasFeature(Embedded) || os(WASI)
+        let mutex = Mutex<Void>(())
+        #endif
+
         final func withLock<Result, Failure: Error>(_ body: () throws(Failure) -> Result) throws(Failure) -> Result {
+            #if !hasFeature(Embedded) || os(WASI)
+            try self.mutex.withLock { _ throws(Failure) in
+                try body()
+            }
+            #else
+            // No Mutex
             try body()
+            #endif
         }
         #endif
 
@@ -113,7 +124,7 @@ public struct HTTPFields: Sendable, Hashable {
         }
     }
 
-    #if !hasFeature(Embedded)
+    #if canImport(Darwin) && !hasFeature(Embedded)
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     private final class _StorageWithMutex: _Storage, @unchecked Sendable {
         let mutex = Mutex<Void>(())
@@ -125,7 +136,6 @@ public struct HTTPFields: Sendable, Hashable {
         }
     }
 
-    #if canImport(Darwin)
     private final class _StorageWithNIOLock: _Storage, @unchecked Sendable {
         let lock = LockStorage.create(value: ())
 
@@ -136,19 +146,16 @@ public struct HTTPFields: Sendable, Hashable {
         }
     }
     #endif
-    #endif
 
     private var _storage = {
-        #if hasFeature(Embedded)
-        _Storage()
-        #elseif canImport(Darwin)
+        #if canImport(Darwin) && !hasFeature(Embedded)
         if #available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *) {
             _StorageWithMutex()
         } else {
             _StorageWithNIOLock()
         }
         #else
-        _StorageWithMutex()
+        _Storage()
         #endif
     }()
 

--- a/Sources/HTTPTypes/HTTPFields.swift
+++ b/Sources/HTTPTypes/HTTPFields.swift
@@ -31,11 +31,11 @@ public struct HTTPFields: Sendable, Hashable {
         }
 
         #if !hasFeature(Embedded)
-        func withLock<Result>(_ body: () throws -> Result) rethrows -> Result {
+        func withLock<Result, Failure: Error>(_ body: () throws(Failure) -> Result) throws(Failure) -> Result {
             fatalError()
         }
         #else
-        final func withLock<Result>(_ body: () throws -> Result) rethrows -> Result {
+        final func withLock<Result, Failure: Error>(_ body: () throws(Failure) -> Result) throws(Failure) -> Result {
             try body()
         }
         #endif
@@ -118,7 +118,7 @@ public struct HTTPFields: Sendable, Hashable {
     private final class _StorageWithMutex: _Storage, @unchecked Sendable {
         let mutex = Mutex<Void>(())
 
-        override func withLock<Result>(_ body: () throws -> Result) rethrows -> Result {
+        override func withLock<Result, Failure: Error>(_ body: () throws(Failure) -> Result) throws(Failure) -> Result {
             try self.mutex.withLock { _ in
                 try body()
             }
@@ -129,7 +129,7 @@ public struct HTTPFields: Sendable, Hashable {
     private final class _StorageWithNIOLock: _Storage, @unchecked Sendable {
         let lock = LockStorage.create(value: ())
 
-        override func withLock<Result>(_ body: () throws -> Result) rethrows -> Result {
+        override func withLock<Result, Failure: Error>(_ body: () throws(Failure) -> Result) throws(Failure) -> Result {
             try self.lock.withLockedValue { _ in
                 try body()
             }

--- a/Sources/HTTPTypes/HTTPFields.swift
+++ b/Sources/HTTPTypes/HTTPFields.swift
@@ -30,9 +30,15 @@ public struct HTTPFields: Sendable, Hashable {
         required init() {
         }
 
+        #if !hasFeature(Embedded)
         func withLock<Result>(_ body: () throws -> Result) rethrows -> Result {
             fatalError()
         }
+        #else
+        final func withLock<Result>(_ body: () throws -> Result) rethrows -> Result {
+            try body()
+        }
+        #endif
 
         var ensureIndex: [String: (first: UInt16, last: UInt16)] {
             self.withLock {
@@ -107,6 +113,7 @@ public struct HTTPFields: Sendable, Hashable {
         }
     }
 
+    #if !hasFeature(Embedded)
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     private final class _StorageWithMutex: _Storage, @unchecked Sendable {
         let mutex = Mutex<Void>(())
@@ -129,9 +136,12 @@ public struct HTTPFields: Sendable, Hashable {
         }
     }
     #endif
+    #endif
 
     private var _storage = {
-        #if canImport(Darwin)
+        #if hasFeature(Embedded)
+        _Storage()
+        #elseif canImport(Darwin)
         if #available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *) {
             _StorageWithMutex()
         } else {
@@ -166,13 +176,14 @@ public struct HTTPFields: Sendable, Hashable {
             let fields = self.fields(for: name)
             if fields.first(where: { _ in true }) != nil {
                 let separator = name == .cookie ? "; " : ", "
-                return fields.lazy.map(\.value).joined(separator: separator)
+                return fields.lazy.map { $0.value }.joined(separator: separator)
             } else {
                 return nil
             }
         }
         set {
             if let newValue {
+                #if !hasFeature(Embedded)
                 if #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *),
                     name == .cookie
                 {
@@ -182,9 +193,10 @@ public struct HTTPFields: Sendable, Hashable {
                         },
                         for: name
                     )
-                } else {
-                    self.setFields(CollectionOfOne(HTTPField(name: name, value: newValue)), for: name)
+                    return
                 }
+                #endif
+                self.setFields(CollectionOfOne(HTTPField(name: name, value: newValue)), for: name)
             } else {
                 self.setFields(EmptyCollection(), for: name)
             }
@@ -194,7 +206,7 @@ public struct HTTPFields: Sendable, Hashable {
     /// Access the field values by name as an array of strings. The order of fields is preserved.
     public subscript(values name: HTTPField.Name) -> [String] {
         get {
-            self.fields(for: name).map(\.value)
+            self.fields(for: name).map { $0.value }
         }
         set {
             self.setFields(newValue.lazy.map { HTTPField(name: name, value: $0) }, for: name)
@@ -355,6 +367,8 @@ extension HTTPFields: RangeReplaceableCollection, RandomAccessCollection, Mutabl
     }
 }
 
+#if !hasFeature(Embedded)
+
 extension HTTPFields: CustomDebugStringConvertible {
     public var debugDescription: String {
         self._storage.fields.description
@@ -384,6 +398,8 @@ extension HTTPFields: Codable {
         }
     }
 }
+
+#endif
 
 extension Array {
     // `removalIndices` must be ordered.

--- a/Sources/HTTPTypes/HTTPFields.swift
+++ b/Sources/HTTPTypes/HTTPFields.swift
@@ -119,7 +119,7 @@ public struct HTTPFields: Sendable, Hashable {
         let mutex = Mutex<Void>(())
 
         override func withLock<Result, Failure: Error>(_ body: () throws(Failure) -> Result) throws(Failure) -> Result {
-            try self.mutex.withLock { _ in
+            try self.mutex.withLock { _ throws(Failure) in
                 try body()
             }
         }
@@ -130,7 +130,7 @@ public struct HTTPFields: Sendable, Hashable {
         let lock = LockStorage.create(value: ())
 
         override func withLock<Result, Failure: Error>(_ body: () throws(Failure) -> Result) throws(Failure) -> Result {
-            try self.lock.withLockedValue { _ in
+            try self.lock.withLockedValue { _ throws(Failure) in
                 try body()
             }
         }

--- a/Sources/HTTPTypes/HTTPFields.swift
+++ b/Sources/HTTPTypes/HTTPFields.swift
@@ -35,17 +35,17 @@ public struct HTTPFields: Sendable, Hashable {
             fatalError()
         }
         #else
-        #if !hasFeature(Embedded) || os(WASI)
+        #if !hasFeature(Embedded) || (os(WASI) && compiler(>=6.4))
         let mutex = Mutex<Void>(())
         #endif
 
         final func withLock<Result, Failure: Error>(_ body: () throws(Failure) -> Result) throws(Failure) -> Result {
-            #if !hasFeature(Embedded) || os(WASI)
+            #if !hasFeature(Embedded) || (os(WASI) && compiler(>=6.4))
             try self.mutex.withLock { _ throws(Failure) in
                 try body()
             }
             #else
-            // No Mutex
+            // Mutex not available
             try body()
             #endif
         }

--- a/Sources/HTTPTypes/HTTPParsedFields.swift
+++ b/Sources/HTTPTypes/HTTPParsedFields.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !hasFeature(Embedded)
+
 struct HTTPParsedFields {
     private var method: ISOLatin1String?
     private var scheme: ISOLatin1String?
@@ -234,3 +236,5 @@ extension HTTPFields {
         self = try parsedFields.trailerFields
     }
 }
+
+#endif

--- a/Sources/HTTPTypes/HTTPParsedFields.swift
+++ b/Sources/HTTPTypes/HTTPParsedFields.swift
@@ -12,8 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if !hasFeature(Embedded)
-
 struct HTTPParsedFields {
     private var method: ISOLatin1String?
     private var scheme: ISOLatin1String?
@@ -236,5 +234,3 @@ extension HTTPFields {
         self = try parsedFields.trailerFields
     }
 }
-
-#endif

--- a/Sources/HTTPTypes/HTTPParsedFields.swift
+++ b/Sources/HTTPTypes/HTTPParsedFields.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !hasFeature(Embedded) || compiler(>=6.4)
+
 struct HTTPParsedFields {
     private var method: ISOLatin1String?
     private var scheme: ISOLatin1String?
@@ -234,3 +236,5 @@ extension HTTPFields {
         self = try parsedFields.trailerFields
     }
 }
+
+#endif

--- a/Sources/HTTPTypes/HTTPRequest+URL.swift
+++ b/Sources/HTTPTypes/HTTPRequest+URL.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !hasFeature(Embedded)
+
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else  // canImport(FoundationEssentials)
@@ -214,3 +216,5 @@ extension URL {
         #endif  // !canImport(FoundationEssentials) && canImport(CoreFoundation)
     }
 }
+
+#endif

--- a/Sources/HTTPTypes/HTTPRequest.swift
+++ b/Sources/HTTPTypes/HTTPRequest.swift
@@ -332,6 +332,8 @@ extension HTTPRequest: CustomDebugStringConvertible {
     }
 }
 
+#if !hasFeature(Embedded)
+
 extension HTTPRequest.PseudoHeaderFields: Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.unkeyedContainer()
@@ -449,6 +451,8 @@ extension HTTPRequest: Codable {
         self.headerFields = try container.decode(HTTPFields.self, forKey: .headerFields)
     }
 }
+
+#endif
 
 extension HTTPRequest.Method {
     /// GET

--- a/Sources/HTTPTypes/HTTPResponse.swift
+++ b/Sources/HTTPTypes/HTTPResponse.swift
@@ -263,6 +263,8 @@ extension HTTPResponse: CustomDebugStringConvertible {
     }
 }
 
+#if !hasFeature(Embedded)
+
 extension HTTPResponse.PseudoHeaderFields: Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.unkeyedContainer()
@@ -337,6 +339,8 @@ extension HTTPResponse: Codable {
         self.headerFields = try container.decode(HTTPFields.self, forKey: .headerFields)
     }
 }
+
+#endif
 
 extension HTTPResponse.Status {
     // MARK: 1xx

--- a/Sources/HTTPTypes/ISOLatin1String.swift
+++ b/Sources/HTTPTypes/ISOLatin1String.swift
@@ -28,16 +28,18 @@ struct ISOLatin1String: Sendable, Hashable {
         return string
     }
 
-    private func withISOLatin1BytesSlowPath<Result, Failure: Error>(
-        _ body: (UnsafeBufferPointer<UInt8>) throws(Failure) -> Result
-    ) throws(Failure) -> Result {
-        try withUnsafeTemporaryAllocation(of: UInt8.self, capacity: self._storage.unicodeScalars.count) { buffer throws(Failure) in
+    private func withISOLatin1BytesSlowPath<Return, Failure: Error>(
+        _ body: (UnsafeBufferPointer<UInt8>) throws(Failure) -> Return
+    ) throws(Failure) -> Return {
+        try withUnsafeTemporaryAllocation(of: UInt8.self, capacity: self._storage.unicodeScalars.count) { buffer in
             for (index, scalar) in self._storage.unicodeScalars.enumerated() {
                 assert(scalar.value <= UInt8.max)
                 buffer[index] = UInt8(truncatingIfNeeded: scalar.value)
             }
-            return try body(UnsafeBufferPointer(buffer))
-        }
+            return Result { () throws(Failure) in
+                try body(UnsafeBufferPointer(buffer))
+            }
+        }.get()
     }
 
     init(_ string: String) {

--- a/Sources/HTTPTypes/ISOLatin1String.swift
+++ b/Sources/HTTPTypes/ISOLatin1String.swift
@@ -28,10 +28,10 @@ struct ISOLatin1String: Sendable, Hashable {
         return string
     }
 
-    private func withISOLatin1BytesSlowPath<Result>(
-        _ body: (UnsafeBufferPointer<UInt8>) throws -> Result
-    ) rethrows -> Result {
-        try withUnsafeTemporaryAllocation(of: UInt8.self, capacity: self._storage.unicodeScalars.count) { buffer in
+    private func withISOLatin1BytesSlowPath<Result, Failure: Error>(
+        _ body: (UnsafeBufferPointer<UInt8>) throws(Failure) -> Result
+    ) throws(Failure) -> Result {
+        try withUnsafeTemporaryAllocation(of: UInt8.self, capacity: self._storage.unicodeScalars.count) { buffer throws(Failure) in
             for (index, scalar) in self._storage.unicodeScalars.enumerated() {
                 assert(scalar.value <= UInt8.max)
                 buffer[index] = UInt8(truncatingIfNeeded: scalar.value)
@@ -71,10 +71,14 @@ struct ISOLatin1String: Sendable, Hashable {
         }
     }
 
-    func withUnsafeBytes<Result>(_ body: (UnsafeBufferPointer<UInt8>) throws -> Result) rethrows -> Result {
+    func withUnsafeBytes<Return, Failure: Error>(_ body: (UnsafeBufferPointer<UInt8>) throws(Failure) -> Return) throws(Failure) -> Return {
         if self._storage.isASCII {
             var string = self._storage
-            return try string.withUTF8(body)
+            return try string.withUTF8 { buffer in
+                Result { () throws(Failure) in
+                    try body(buffer)
+                }
+            }.get()
         } else {
             return try self.withISOLatin1BytesSlowPath(body)
         }

--- a/Sources/HTTPTypes/ISOLatin1String.swift
+++ b/Sources/HTTPTypes/ISOLatin1String.swift
@@ -73,7 +73,9 @@ struct ISOLatin1String: Sendable, Hashable {
         }
     }
 
-    func withUnsafeBytes<Return, Failure: Error>(_ body: (UnsafeBufferPointer<UInt8>) throws(Failure) -> Return) throws(Failure) -> Return {
+    func withUnsafeBytes<Return, Failure: Error>(
+        _ body: (UnsafeBufferPointer<UInt8>) throws(Failure) -> Return
+    ) throws(Failure) -> Return {
         if self._storage.isASCII {
             var string = self._storage
             return try string.withUTF8 { buffer in

--- a/Sources/HTTPTypes/NIOLock.swift
+++ b/Sources/HTTPTypes/NIOLock.swift
@@ -176,14 +176,14 @@ final class LockStorage<Value>: ManagedBuffer<Value, LockPrimitive> {
         }
     }
 
-    func withLockPrimitive<T>(_ body: (UnsafeMutablePointer<LockPrimitive>) throws -> T) rethrows -> T {
-        try self.withUnsafeMutablePointerToElements { lockPtr in
+    func withLockPrimitive<T, E: Error>(_ body: (UnsafeMutablePointer<LockPrimitive>) throws(E) -> T) throws(E) -> T {
+        try self.withUnsafeMutablePointerToElements { lockPtr throws(E) in
             try body(lockPtr)
         }
     }
 
-    func withLockedValue<T>(_ mutate: (inout Value) throws -> T) rethrows -> T {
-        try self.withUnsafeMutablePointers { valuePtr, lockPtr in
+    func withLockedValue<T, E: Error>(_ mutate: (inout Value) throws(E) -> T) throws(E) -> T {
+        try self.withUnsafeMutablePointers { valuePtr, lockPtr throws(E) in
             LockOperations.lock(lockPtr)
             defer { LockOperations.unlock(lockPtr) }
             return try mutate(&valuePtr.pointee)


### PR DESCRIPTION
In order for swift-http-api-proposal to support embedded Swift, swift-http-types has to support embedded Swift first.