### PR TITLE
Add FoundationURL trait

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -67,3 +67,30 @@ jobs:
       windows_6_3_enabled: true
       windows_nightly_next_enabled: true
       windows_nightly_main_enabled: true
+
+  construct-linkage-test-matrix:
+    name: Construct linkage matrix
+    runs-on: ubuntu-latest
+    outputs:
+      linkage-test-matrix: '${{ steps.generate-matrix.outputs.linkage-test-matrix }}'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - id: generate-matrix
+        run: echo "linkage-test-matrix=$(curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/generate_matrix.sh | bash)" >> "$GITHUB_OUTPUT"
+        env:
+          MATRIX_LINUX_SETUP_COMMAND: apt-get update -y && apt-get install -yq jq && git config --global --add safe.directory /swift-http-types
+          MATRIX_LINUX_COMMAND: ./scripts/run-linkage-test.sh
+          MATRIX_LINUX_6_0_ENABLED: false
+          MATRIX_LINUX_NIGHTLY_NEXT_ENABLED: false
+          MATRIX_LINUX_NIGHTLY_MAIN_ENABLED: false
+
+  linkage-test:
+    name: Linkage test
+    needs: construct-linkage-test-matrix
+    uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@main
+    with:
+      name: "Linkage test"
+      matrix_string: '${{ needs.construct-linkage-test-matrix.outputs.linkage-test-matrix }}'

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
         .library(name: "HTTPTypesFoundation", targets: ["HTTPTypesFoundation"]),
     ],
     traits: [
-        "FoundationURL",
+        .trait(name: "FoundationURL", description: "Enable HTTPRequest conveniences with Foundation URL"),
         .default(enabledTraits: ["FoundationURL"]),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -8,6 +8,10 @@ let package = Package(
         .library(name: "HTTPTypes", targets: ["HTTPTypes"]),
         .library(name: "HTTPTypesFoundation", targets: ["HTTPTypesFoundation"]),
     ],
+    traits: [
+        "FoundationURL",
+        .default(enabledTraits: ["FoundationURL"]),
+    ],
     targets: [
         .target(name: "HTTPTypes"),
         .target(
@@ -33,7 +37,7 @@ let package = Package(
 
 for target in package.targets {
     var settings = target.swiftSettings ?? []
-    settings.append(.enableExperimentalFeature("StrictConcurrency=complete"))
+    settings.append(.enableUpcomingFeature("InternalImportsByDefault"))
     target.swiftSettings = settings
 }
 

--- a/Sources/HTTPTypes/HTTPRequest+URL.swift
+++ b/Sources/HTTPTypes/HTTPRequest+URL.swift
@@ -12,10 +12,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if FoundationURL
+
 #if canImport(FoundationEssentials)
-import FoundationEssentials
+public import FoundationEssentials
 #else  // canImport(FoundationEssentials)
-import Foundation
+public import Foundation
 #if canImport(CoreFoundation)
 import CoreFoundation
 #endif  // canImport(CoreFoundation)
@@ -214,3 +216,5 @@ extension URL {
         #endif  // !canImport(FoundationEssentials) && canImport(CoreFoundation)
     }
 }
+
+#endif

--- a/Sources/HTTPTypesFoundation/HTTPTypes+ISOLatin1.swift
+++ b/Sources/HTTPTypesFoundation/HTTPTypes+ISOLatin1.swift
@@ -12,8 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import HTTPTypes
-
 extension String {
     var isASCII: Bool {
         self.utf8.allSatisfy { $0 & 0x80 == 0 }

--- a/Sources/HTTPTypesFoundation/URLRequest+HTTPTypes.swift
+++ b/Sources/HTTPTypesFoundation/URLRequest+HTTPTypes.swift
@@ -12,10 +12,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-public import Foundation
-
 #if canImport(FoundationNetworking)
 public import FoundationNetworking
+#else
+public import Foundation
 #endif
 
 #if !os(WASI)

--- a/Sources/HTTPTypesFoundation/URLRequest+HTTPTypes.swift
+++ b/Sources/HTTPTypesFoundation/URLRequest+HTTPTypes.swift
@@ -12,11 +12,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
-import HTTPTypes
+public import Foundation
 
 #if canImport(FoundationNetworking)
-import FoundationNetworking
+public import FoundationNetworking
 #endif
 
 #if !os(WASI)

--- a/Sources/HTTPTypesFoundation/URLResponse+HTTPTypes.swift
+++ b/Sources/HTTPTypesFoundation/URLResponse+HTTPTypes.swift
@@ -12,11 +12,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
-import HTTPTypes
+public import Foundation
 
 #if canImport(FoundationNetworking)
-import FoundationNetworking
+public import FoundationNetworking
 #endif
 
 #if !os(WASI)

--- a/Sources/HTTPTypesFoundation/URLSession+HTTPTypes.swift
+++ b/Sources/HTTPTypesFoundation/URLSession+HTTPTypes.swift
@@ -12,11 +12,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
-import HTTPTypes
+public import Foundation
 
 #if canImport(FoundationNetworking)
-import FoundationNetworking
+public import FoundationNetworking
 #endif
 
 #if !os(WASI)

--- a/Tests/LinkageTest/.gitignore
+++ b/Tests/LinkageTest/.gitignore
@@ -1,0 +1,2 @@
+.build
+Package.resolved

--- a/Tests/LinkageTest/Package.swift
+++ b/Tests/LinkageTest/Package.swift
@@ -1,0 +1,18 @@
+// swift-tools-version: 6.1
+
+import PackageDescription
+
+let package = Package(
+    name: "linkage-test",
+    dependencies: [
+        .package(name: "swift-http-types", path: "../..", traits: [])
+    ],
+    targets: [
+        .executableTarget(
+            name: "linkageTest",
+            dependencies: [
+                .product(name: "HTTPTypes", package: "swift-http-types")
+            ]
+        )
+    ]
+)

--- a/Tests/LinkageTest/Sources/linkageTest/main.swift
+++ b/Tests/LinkageTest/Sources/linkageTest/main.swift
@@ -1,0 +1,17 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import HTTPTypes
+
+print("\(HTTPRequest.self)")

--- a/scripts/run-linkage-test.sh
+++ b/scripts/run-linkage-test.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift open source project
+##
+## Copyright (c) 2026 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of Swift project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+set -eu
+
+# Validate that we're running on Linux
+if [[ "$(uname -s)" != "Linux" ]]; then
+    echo "Error: This script must be run on Linux. Current OS: $(uname -s)" >&2
+    exit 1
+fi
+
+echo "Running on Linux - proceeding with linkage test..."
+
+# Build the linkage test package
+echo "Building linkage test package..."
+swift build --package-path Tests/LinkageTest
+
+# Check the architecture and build path
+ARCH=$(uname -m)
+if [[ "$ARCH" == "x86_64" ]]; then
+    BUILD_PATH="Tests/LinkageTest/.build/x86_64-unknown-linux-gnu/debug/linkageTest"
+elif [[ "$ARCH" == "aarch64" ]]; then
+    BUILD_PATH="Tests/LinkageTest/.build/aarch64-unknown-linux-gnu/debug/linkageTest"
+else
+    echo "Error: Unsupported architecture: $ARCH" >&2
+    exit 1
+fi
+
+# Verify the binary exists
+if [[ ! -f "$BUILD_PATH" ]]; then
+    echo "Error: Built binary not found at $BUILD_PATH" >&2
+    exit 1
+fi
+
+echo "Checking linkage for binary: $BUILD_PATH"
+
+# Run ldd and check if libFoundation* is linked
+LDD_OUTPUT=$(ldd "$BUILD_PATH")
+echo "LDD output:"
+echo "$LDD_OUTPUT"
+
+if echo "$LDD_OUTPUT" | grep -q "libFoundation"; then
+    echo "Error: Binary is linked against libFoundation* - this indicates incorrect linkage. Ensure the full Foundation is not linked on Linux when default traits are disabled." >&2
+    exit 1
+else
+    echo "Success: Binary is not linked against libFoundation* - linkage test passed."
+fi


### PR DESCRIPTION
Add a default enabled trait "FoundationURL" that can be disabled for users who don't want Foundation dependencies. Also enable `InternalImportsByDefault`.