### PR TITLE
Add FreeBSD pthread support to NIOLock.

### DIFF
--- a/Sources/HTTPTypes/NIOLock.swift
+++ b/Sources/HTTPTypes/NIOLock.swift
@@ -49,6 +49,8 @@ import wasi_pthread
 typealias LockPrimitive = SRWLOCK
 #elseif canImport(Darwin)
 typealias LockPrimitive = os_unfair_lock
+#elseif os(FreeBSD) || os(OpenBSD)
+typealias LockPrimitive = pthread_mutex_t?
 #else
 typealias LockPrimitive = pthread_mutex_t
 #endif
@@ -64,7 +66,11 @@ extension LockOperations {
         #elseif canImport(Darwin)
         mutex.initialize(to: .init())
         #elseif (compiler(<6.1) && !os(WASI)) || (compiler(>=6.1) && _runtime(_multithreaded))
+        #if os(FreeBSD) || os(OpenBSD)
+        var attr = pthread_mutexattr_t(bitPattern: 0)
+        #else
         var attr = pthread_mutexattr_t()
+        #endif
         pthread_mutexattr_init(&attr)
 
         let err = pthread_mutex_init(mutex, &attr)


### PR DESCRIPTION
### Motivation

`NIOLock`'s pthread fallback branch (used when neither Windows
`SRWLOCK` nor Darwin `os_unfair_lock` is available) types
`LockPrimitive` as `pthread_mutex_t` and initializes
`pthread_mutexattr_t` with a default initializer. Both compile on Linux
but fail on FreeBSD / OpenBSD, where `pthread_mutex_t` and
`pthread_mutexattr_t` are opaque-pointer typedefs that Swift imports as
`Optional<OpaquePointer>`, so the no-argument initializers don't exist.

This blocks Swift HTTP Types — and anything that transitively depends
on it (Hummingbird, downstream HTTP servers) — from compiling on
FreeBSD with the official Swift FreeBSD preview toolchain.

### Modifications

Mirror the pattern already landed in [apple/swift-log#387][log-pr] (and
matching apple/swift-nio's `Sources/NIOConcurrencyHelpers/NIOLock.swift`
after #3494 / #3587):

- On `os(FreeBSD) || os(OpenBSD)` alias `LockPrimitive` to
  `pthread_mutex_t?` so a `UnsafeMutablePointer<LockPrimitive>` lines
  up with the `UnsafeMutablePointer<pthread_mutex_t?>` parameter
  `pthread_mutex_init` / `_destroy` / `_lock` / `_unlock` expect.
- In `LockOperations.create(_:)`, wrap `pthread_mutexattr_t()` with
  `#if os(FreeBSD) || os(OpenBSD)` to use the `bitPattern:` overload
  instead.

[log-pr]: https://github.com/apple/swift-log/pull/387

Touches one file (`Sources/HTTPTypes/NIOLock.swift`), +6 lines, all
behind FreeBSD/OpenBSD conditionals. No behaviour change on existing
platforms.

### Result

`swift build` and `swift test` both clean on FreeBSD 15.0 with the
official Swift FreeBSD preview toolchain (`swift_6.3-dev`):

```
$ uname -a
FreeBSD swiftbuild 15.0-RELEASE FreeBSD 15.0-RELEASE-p9 releng/15.0-n281048-6d536196f1bd GENERIC amd64

$ swift --version
Swift version 6.3-dev (LLVM 972b62858355d07, Swift 3f8c798cfe25bbb)
Target: x86_64-unknown-freebsd14.3
Build config: +assertions

$ swift build
Building for debugging...
... 13 modules ...
Build complete! (13.83s)

$ swift test
... 20 tests, 0 failures ...
✔ Test run with 0 tests in 0 suites passed after 0.001 seconds.
```

Without this change every module above `HTTPTypes` fails to compile on
the same toolchain — verified by reverting just the `NIOLock.swift`
hunks and rebuilding.

### Checks

- [x] Builds on Linux/Darwin (no change there, all changes guarded
      behind `#if os(FreeBSD) || os(OpenBSD)`).
- [x] Builds + passes existing tests on FreeBSD 15.0 with Swift
      6.3-dev preview toolchain.
- [x] Pattern matches [apple/swift-log#387][log-pr] (NIOLock copy in
      swift-log).
- [x] Patch is concise (6 LOC, single file, single concern).
