### PR TITLE
Check that the decoded field value string is actually ISOLatin1

### DIFF
--- a/Sources/HTTPTypes/HTTPField.swift
+++ b/Sources/HTTPTypes/HTTPField.swift
@@ -245,7 +245,7 @@ extension HTTPField: Codable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let name = try container.decode(Name.self, forKey: .name)
         let value = try container.decode(String.self, forKey: .value)
-        guard Self.isValidValue(value) else {
+        guard value.unicodeScalars.allSatisfy({ $0.value <= UInt8.max }) && Self.isValidValue(value) else {
             throw DecodingError.dataCorruptedError(
                 forKey: .value,
                 in: container,


### PR DESCRIPTION
The decoder assumes that the string is within the ISOLatin1 range without checking, potentially allowing invalid values to be saved in an HTTPField

rdar://178437865