### PR TITLE
Add isSafe and isIdempotent to HTTPRequest.Method

### DIFF
--- a/Sources/HTTPTypes/HTTPRequest.swift
+++ b/Sources/HTTPTypes/HTTPRequest.swift
@@ -502,8 +502,43 @@ extension HTTPRequest.Method {
 
     /// CONNECT-UDP
     static var connectUDP: Self { .init(unchecked: "CONNECT-UDP") }
+}
 
-    var isSafe: Bool {
-        self == .get || self == .head || self == .options || self == .query
+extension HTTPRequest.Method {
+    /// Whether the request method is "safe" as defined by RFC 9110.
+    ///
+    /// A request method is "safe" if its defined semantics are essentially read-only; the client
+    /// does not request, and does not expect, any state change on the origin server as a result of
+    /// applying a safe method to a target resource. Of the methods defined by RFC 9110, `GET`,
+    /// `HEAD`, `OPTIONS`, and `TRACE` are safe.
+    ///
+    /// All safe methods are also ``isIdempotent``.
+    ///
+    /// https://www.rfc-editor.org/rfc/rfc9110.html#name-safe-methods
+    public var isSafe: Bool {
+        switch self {
+        case .get, .head, .options, .trace, .query:
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// Whether the request method is "idempotent" as defined by RFC 9110.
+    ///
+    /// A request method is "idempotent" if the intended effect on the server of multiple identical
+    /// requests with that method is the same as the effect for a single such request. Of the
+    /// methods defined by RFC 9110, `PUT` and `DELETE`, along with every ``isSafe`` method, are
+    /// idempotent. Idempotency is useful for deciding whether a failed request may be retried
+    /// automatically.
+    ///
+    /// https://www.rfc-editor.org/rfc/rfc9110.html#name-idempotent-methods
+    public var isIdempotent: Bool {
+        switch self {
+        case .put, .delete:
+            return true
+        default:
+            return self.isSafe
+        }
     }
 }

--- a/Tests/HTTPTypesTests/HTTPTypesTests.swift
+++ b/Tests/HTTPTypesTests/HTTPTypesTests.swift
@@ -249,6 +249,31 @@ final class HTTPTypesTests: XCTestCase {
         XCTAssertEqual(trailerFields[HTTPField.Name("trailer2")!], "value2")
     }
 
+    func testMethodSafety() {
+        for method in [HTTPRequest.Method.get, .head, .options, .trace] {
+            XCTAssertTrue(method.isSafe, "\(method) should be safe")
+            XCTAssertTrue(method.isIdempotent, "safe method \(method) should be idempotent")
+        }
+        for method in [HTTPRequest.Method.put, .delete] {
+            XCTAssertFalse(method.isSafe, "\(method) should not be safe")
+            XCTAssertTrue(method.isIdempotent, "\(method) should be idempotent")
+        }
+        for method in [HTTPRequest.Method.post, .connect, .patch] {
+            XCTAssertFalse(method.isSafe, "\(method) should not be safe")
+            XCTAssertFalse(method.isIdempotent, "\(method) should not be idempotent")
+        }
+    }
+
+    func testMethodSafetyFromString() {
+        // Semantics are derived from the method token, not just the static members.
+        XCTAssertTrue(HTTPRequest.Method("GET")!.isSafe)
+        XCTAssertTrue(HTTPRequest.Method("DELETE")!.isIdempotent)
+        XCTAssertFalse(HTTPRequest.Method("POST")!.isIdempotent)
+        // Unknown methods are conservatively treated as neither safe nor idempotent.
+        XCTAssertFalse(HTTPRequest.Method("FROBNICATE")!.isSafe)
+        XCTAssertFalse(HTTPRequest.Method("FROBNICATE")!.isIdempotent)
+    }
+
     func testTypeLayoutSize() {
         XCTAssertEqual(MemoryLayout<HTTPRequest>.size, MemoryLayout<AnyObject>.size * 2)
         XCTAssertEqual(MemoryLayout<HTTPResponse>.size, MemoryLayout<AnyObject>.size * 2)


### PR DESCRIPTION
### Motivation

RFC 9110 classifies request methods by two properties that HTTP clients and servers frequently need:

- **Safe** (§9.2.1): the method has essentially read-only semantics — the client does not request, and does not expect, any state change on the origin server.
- **Idempotent** (§9.2.2): repeating an identical request has the same intended effect as making it once.

These drive everyday decisions like *"may I automatically retry this failed request?"* and *"is this response cacheable?"*. Today a user has to hand-maintain their own set of method names to answer them.

### What this does

`HTTPRequest.Method` already carried an **internal** `isSafe` helper, but it was:

1. **Dead code** — never referenced anywhere in the package, so unusable by clients.
2. **Incorrect** — it omitted `TRACE`, which RFC 9110 defines as safe.

This replaces it with two public, documented computed properties:

| Property | `true` for |
|---|---|
| `isSafe` | `GET`, `HEAD`, `OPTIONS`, `TRACE` (and the `QUERY` draft method the type already models) |
| `isIdempotent` | every safe method, plus `PUT` and `DELETE` |

Because the classification is derived from the method token, it works for methods built from arbitrary strings (`HTTPRequest.Method("GET")`) as well as the static members. Unknown methods are conservatively reported as neither safe nor idempotent.

```swift
HTTPRequest.Method.get.isSafe          // true
HTTPRequest.Method.get.isIdempotent    // true  (safe ⇒ idempotent)
HTTPRequest.Method.delete.isSafe       // false
HTTPRequest.Method.delete.isIdempotent // true
HTTPRequest.Method.post.isIdempotent   // false
```

### Testing

Adds `testMethodSafety` and `testMethodSafetyFromString` covering the safe, idempotent-but-unsafe, and neither buckets, plus classification of methods constructed from strings. Full suite (22 tests) passes.

### Notes

- Purely additive public API; no behavior changes to existing functionality.
- The removed `isSafe` was `internal` and unused, so nothing in the package depended on it.

References:
- https://www.rfc-editor.org/rfc/rfc9110.html#name-safe-methods
- https://www.rfc-editor.org/rfc/rfc9110.html#name-idempotent-methods